### PR TITLE
feat: add pytorch project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,9 +174,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the enitre vscode folder
 # .vscode/
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ A great beginner project is to train a neural network that can recognize handwri
 - Each image is only 28×28 pixels in grayscale, making training relatively quick.
 - Tutorials and code examples are widely available if you get stuck.
 
+## Project Layout
+
+```
+.
+├── data/                  # datasets are downloaded here
+├── src/
+│   └── pytorch_playground/
+│       ├── data.py        # helpers for loading datasets
+│       ├── model.py       # the SimpleNet definition
+│       └── train.py       # training loop for MNIST
+├── tests/                 # basic unit tests
+├── requirements.txt       # runtime dependencies
+├── requirements-dev.txt   # tooling for development
+└── README.md
+```
+
 ## Getting Started
 
 1. **Install Python 3.8 or newer.** Creating a virtual environment is recommended:
@@ -20,47 +36,26 @@ A great beginner project is to train a neural network that can recognize handwri
    source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
    ```
 
-2. **Install PyTorch and supporting libraries.** Visit <https://pytorch.org> for the command specific to your system. A typical CPU-only install looks like:
+2. **Install dependencies.**
 
    ```bash
-   pip install torch torchvision
+   pip install -r requirements.txt         # runtime packages
+   pip install -r requirements-dev.txt     # tools like black, ruff, pytest
    ```
 
-3. **Clone this repository** (if you haven't already) and add your own training script. You can start from the following minimal example that trains a simple network:
+3. **Run the example training script.** This downloads MNIST to the `data/` directory and trains a small neural network:
 
-   ```python
-   import torch
-   from torch import nn
-   from torchvision import datasets, transforms
-
-   train_data = datasets.MNIST(
-       root="./data", train=True, download=True,
-       transform=transforms.ToTensor()
-   )
-   train_loader = torch.utils.data.DataLoader(train_data, batch_size=64, shuffle=True)
-
-   model = nn.Sequential(
-       nn.Flatten(),
-       nn.Linear(28 * 28, 128),
-       nn.ReLU(),
-       nn.Linear(128, 10)
-   )
-   loss_fn = nn.CrossEntropyLoss()
-   optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
-
-   for epoch in range(5):
-       for images, labels in train_loader:
-           preds = model(images)
-           loss = loss_fn(preds, labels)
-
-           optimizer.zero_grad()
-           loss.backward()
-           optimizer.step()
-
-       print(f"Epoch {epoch+1}, loss={loss.item():.4f}")
+   ```bash
+   python -m pytorch_playground.train
    ```
 
-4. **Run your script** to start training and watch the loss decrease as the model learns. From there you can experiment with different network architectures, optimizers, or datasets such as Fashion-MNIST or CIFAR-10.
+4. **Run tests** to make sure everything is working:
+
+   ```bash
+   pytest
+   ```
+
+From here you can experiment with different network architectures, optimizers, or datasets such as Fashion-MNIST or CIFAR-10.
 
 ## Next Steps
 
@@ -69,4 +64,3 @@ A great beginner project is to train a neural network that can recognize handwri
 - Save the trained model and load it later for predictions.
 
 This repository is intentionally kept simple. Feel free to modify the example, add notebooks, or expand it into more complex projects as you learn.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "pytorch-playground"
+version = "0.1.0"
+description = "Learning playground for PyTorch"
+requires-python = ">=3.8"
+dependencies = ["torch", "torchvision"]
+
 [tool.black]
 line-length = 88
 target-version = ['py39']

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -ra
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torchvision

--- a/src/pytorch_playground/__init__.py
+++ b/src/pytorch_playground/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for the PyTorch playground package."""

--- a/src/pytorch_playground/data.py
+++ b/src/pytorch_playground/data.py
@@ -1,0 +1,52 @@
+"""Dataset utilities for the playground."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+
+def get_dataloaders(
+    batch_size: int = 64, use_fake_data: bool = False
+) -> Tuple[DataLoader, DataLoader]:
+    """Return training and test dataloaders.
+
+    Args:
+    ----
+        batch_size: Number of items per batch.
+        use_fake_data: If True, return loaders built from ``datasets.FakeData`` to
+            avoid downloading the real dataset. Helpful for tests.
+    """
+    transform = transforms.ToTensor()
+    if use_fake_data:
+        train_dataset = datasets.FakeData(
+            size=64,
+            image_size=(1, 28, 28),
+            num_classes=10,
+            transform=transform,
+        )
+        test_dataset = datasets.FakeData(
+            size=64,
+            image_size=(1, 28, 28),
+            num_classes=10,
+            transform=transform,
+        )
+    else:
+        train_dataset = datasets.MNIST(
+            root="data",
+            train=True,
+            download=True,
+            transform=transform,
+        )
+        test_dataset = datasets.MNIST(
+            root="data",
+            train=False,
+            download=True,
+            transform=transform,
+        )
+
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size)
+    return train_loader, test_loader

--- a/src/pytorch_playground/model.py
+++ b/src/pytorch_playground/model.py
@@ -1,0 +1,23 @@
+"""Model definitions for the playground."""
+
+from __future__ import annotations
+
+from torch import nn
+
+
+class SimpleNet(nn.Module):
+    """A small neural network for MNIST digits."""
+
+    def __init__(self) -> None:
+        """Create network layers."""
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(28 * 28, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+
+    def forward(self, x):  # type: ignore[override]
+        """Compute logits for a batch of images."""
+        return self.net(x)

--- a/src/pytorch_playground/train.py
+++ b/src/pytorch_playground/train.py
@@ -1,0 +1,34 @@
+"""Training utilities for the playground."""
+
+from __future__ import annotations
+
+from torch import nn
+from torch.optim import SGD
+
+from .data import get_dataloaders
+from .model import SimpleNet
+
+
+def train(num_epochs: int = 5, batch_size: int = 64, lr: float = 0.01) -> SimpleNet:
+    """Train ``SimpleNet`` on the MNIST dataset."""
+    train_loader, _ = get_dataloaders(batch_size=batch_size)
+    model = SimpleNet()
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = SGD(model.parameters(), lr=lr)
+
+    for epoch in range(num_epochs):
+        running_loss = 0.0
+        for images, labels in train_loader:
+            preds = model(images)
+            loss = loss_fn(preds, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+        avg_loss = running_loss / len(train_loader)
+        print(f"Epoch {epoch + 1}: loss={avg_loss:.4f}")
+    return model
+
+
+if __name__ == "__main__":
+    train()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,26 @@
+"""Basic smoke tests for the PyTorch playground."""
+
+from __future__ import annotations
+
+import torch
+from pytorch_playground.data import get_dataloaders
+from pytorch_playground.model import SimpleNet
+
+
+def test_get_dataloaders_fake():
+    """Dataloaders should yield tensors with expected shapes."""
+    train_loader, test_loader = get_dataloaders(batch_size=16, use_fake_data=True)
+    images, labels = next(iter(train_loader))
+    assert images.shape == (16, 1, 28, 28)
+    assert labels.shape == (16,)
+    images, labels = next(iter(test_loader))
+    assert images.shape == (16, 1, 28, 28)
+    assert labels.shape == (16,)
+
+
+def test_model_forward():
+    """Model forward pass returns logits for each class."""
+    model = SimpleNet()
+    x = torch.randn(4, 1, 28, 28)
+    out = model(x)
+    assert out.shape == (4, 10)


### PR DESCRIPTION
## Summary
- scaffold PyTorch playground with dataset loaders, simple model and training script
- add basic smoke tests and development config
- document project layout and usage instructions

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e74503e34832cb356224f1e05689c