### PR TITLE
ci: add build job and fix lint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,19 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pytest ruff
       - name: Run lint
-        run: ruff .
+        run: ruff check .
       - name: Run tests
         run: pytest
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,6 @@ target-version = ['py39']
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 extend-select = ["I", "D"]

--- a/src/pytorch_playground/data.py
+++ b/src/pytorch_playground/data.py
@@ -14,10 +14,10 @@ def get_dataloaders(
     """Return training and test dataloaders.
 
     Args:
-    ----
         batch_size: Number of items per batch.
         use_fake_data: If True, return loaders built from ``datasets.FakeData`` to
             avoid downloading the real dataset. Helpful for tests.
+
     """
     transform = transforms.ToTensor()
     if use_fake_data:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import torch
+
 from pytorch_playground.data import get_dataloaders
 from pytorch_playground.model import SimpleNet
 


### PR DESCRIPTION
## Summary
- fix ruff lint issues in data utilities and tests
- update ruff config and workflow to use `ruff check`
- add CI job to build the package with `python -m build`

## Testing
- `ruff check .`
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_689e857d47c4832c836b449a20c9296e